### PR TITLE
fix: Wrap raw system text in LPML event tags

### DIFF
--- a/src/core/control/engine.js
+++ b/src/core/control/engine.js
@@ -155,7 +155,7 @@
 
 				// 暴走チェック
 				if (this.continuousToolCount >= this.MAX_CONTINUOUS_TOOLS) {
-					this.state.history.append(Role.SYSTEM, `System Alert: Max continuous tool executions (${this.MAX_CONTINUOUS_TOOLS}) reached. Auto-trigger paused.`, {
+					this.state.history.append(Role.SYSTEM, `<event type="system_alert">\nSystem Alert: Max continuous tool executions (${this.MAX_CONTINUOUS_TOOLS}) reached. Auto-trigger paused.\n</event>`, {
 						type: TurnType.ERROR,
 						trigger_llm: false
 					});
@@ -227,7 +227,7 @@
 					});
 				} else {
 					console.error('[Engine] Error:', error);
-					const errTurn = this.state.history.append(Role.SYSTEM, `System Error: ${error.message}`, {
+					const errTurn = this.state.history.append(Role.SYSTEM, `<event type="system_error">\nSystem Error: ${error.message}\n</event>`, {
 						type: TurnType.ERROR,
 						trigger_llm: false
 					});

--- a/src/shell/core/shell_controller.js
+++ b/src/shell/core/shell_controller.js
@@ -601,7 +601,7 @@
 				const activeToolDefs = this.registry.getActiveDynamicToolDefinitions();
 				if (activeToolDefs.length > 0) {
 					const defsText = activeToolDefs.join('\n');
-					history.append(global.Itera.Role.SYSTEM, `[System: Restored Dynamic Tools]\nThe following tools are currently active from background processes:\n${defsText}`, {
+					history.append(global.Itera.Role.SYSTEM, `<event type="tool_available">\n[System: Restored Dynamic Tools]\nThe following tools are currently active from background processes:\n${defsText}\n</event>`, {
 						type: 'tool_available',
 						trigger_llm: false
 					});
@@ -610,7 +610,7 @@
 
 			// 4. 引き継ぎ情報の注入
 			if (summary) {
-				history.append(global.Itera.Role.SYSTEM, `[Session Restored & Context Compressed]\n\n${summary}`, {
+				history.append(global.Itera.Role.SYSTEM, `<event type="session_reset">\n[Session Restored & Context Compressed]\n\n${summary}\n</event>`, {
 					type: 'event_log',
 					trigger_llm: triggerLlm
 				});


### PR DESCRIPTION

## 概要
LLM のコンテキスト（APIプロンプト）に、LPMLタグ（`<event>` 等）で囲まれていない生テキストが `SYSTEM` ロールとして混入する問題を修正しました。

## 修正内容（アドホック）
以下の箇所において、`history.append` に渡す文字列を直接 `<event>` タグで囲むようにしました。
1. `engine.js`: ツール暴走検知時のアラートメッセージ (`<event type="system_alert">`)
2. `engine.js`: システムエラー発生時のメッセージ (`<event type="system_error">`)
3. `shell_controller.js`: 動的ツールのリストア通知 (`<event type="tool_available">`)
4. `shell_controller.js`: セッションリセット後の引き継ぎ情報 (`<event type="session_reset">`)

## 今後の課題
今回の修正は対症療法（アドホック）です。将来的には `History` クラスの拡張や専用のイベント発行API（`emitSystemEvent`）を導入し、呼び出し側でLPML構文を意識させない設計へのリファクタリングを推奨します。
