### PR TITLE
feat(vfs): Add base64 encoding support for read/write

### DIFF
--- a/src/api/guest/metaos_core.js
+++ b/src/api/guest/metaos_core.js
@@ -24,7 +24,7 @@
     global.MetaOS = {
         // 1. ファイルシステム (VFS)
         fs: {
-            read: async (path) => transport.requestHost('fs:read', { path }),
+            read: async (path, opts = {}) => transport.requestHost('fs:read', { path, opts }),
             write: async (path, content, opts = {}) => transport.requestHost('fs:write', { path, content, opts }),
             append: async (path, content, opts = {}) => transport.requestHost('fs:append', { path, content, opts }),
             delete: async (path, opts = {}) => transport.requestHost('fs:delete', { path, opts }),

--- a/src/api/host/api_router.js
+++ b/src/api/host/api_router.js
@@ -34,15 +34,16 @@
 			// 1. File System (fs)
 			// ==========================================
 			t.registerHandler('fs:read', async ({
-				path
-			}) => d.vfs.readFile(path));
+				path,
+				opts
+			}) => d.vfs.readFile(path, opts));
 
 			t.registerHandler('fs:write', async ({
 				path,
 				content,
 				opts
 			}) => {
-				const res = d.vfs.writeFile(path, content);
+				const res = d.vfs.writeFile(path, content, opts);
 				this._checkAndEmitEvent(opts, 'file_edited', `User App edited file: ${path}`);
 				return res;
 			});

--- a/src/core/state/vfs.js
+++ b/src/core/state/vfs.js
@@ -133,18 +133,38 @@
             throw new Error(`Path not found: ${path}`);
         }
 
-        readFile(path) {
+        readFile(path, opts = {}) {
             const p = this._norm(path);
             if (!this.isFile(p)) throw new Error(`File not found: ${p}`);
-            return this.files[p].content;
+            
+            let content = this.files[p].content;
+            
+            if (opts && opts.encoding === 'base64') {
+                if (content.startsWith('data:')) {
+                    const commaIdx = content.indexOf(',');
+                    if (commaIdx !== -1) {
+                        return content.slice(commaIdx + 1);
+                    }
+                } else {
+                    // Plain text stored as string, convert to base64
+                    return btoa(unescape(encodeURIComponent(content)));
+                }
+            }
+            
+            return content;
         }
 
-        writeFile(path, content) {
+        writeFile(path, content, opts = {}) {
             const p = this._norm(path);
             if (!p) throw new Error("Cannot write to root path.");
 
             if (!this.isFile(p) && this.isDirectory(p)) {
                 throw new Error(`Cannot write file: A directory already exists at ${p}`);
+            }
+            
+            if (opts && opts.encoding === 'base64') {
+                const mime = opts.mimeType || 'application/octet-stream';
+                content = `data:${mime};base64,${content}`;
             }
 
             const now = Date.now();


### PR DESCRIPTION

## 概要
Guestアプリやデーモンから生バイナリ（Uint8Array等）を扱うため、VFS (`MetaOS.fs`) の読み書きに `encoding: "base64"` オプションを追加しました。

## 変更内容
1. **`src/core/state/vfs.js`**
   - 内部データは既存の文字列（Data URL）のまま維持し、破壊的変更を防止。
   - `opts.encoding === 'base64'` 指定時のみ、`data:...;base64,` プレフィックスの自動付与（保存時）と自動除去（読み込み時）を実行するように改修。
2. **`src/api/host/api_router.js`**
   - Guestから飛んでくる `opts` パラメータを `vfs.readFile` および `writeFile` へ透過的に渡すようルーティング処理を修正。
3. **`src/api/guest/metaos_core.js`**
   - Guest側のブリッジ API (`MetaOS.fs.read`) が `opts` オブジェクトを受け取って IPC パススルーできるようにインターフェースを修正。

## 備考
この改修により、Google Driveデーモンなどからの外部通信において、手動でData URLヘッダーをパースする手間が省け、クリーンなBase64送受信が可能になります。既存のテキストベースのファイル操作（正規表現置換など）や画像プレビュー機能は一切影響を受けません。
