### PR TITLE
Fix: Mobile window.name reset in Blob URLs (PID Injection)

### DIFF
--- a/src/api/guest/guest_builder.js
+++ b/src/api/guest/guest_builder.js
@@ -24,8 +24,8 @@
     // ==========================================
     // 2. Transport Initialization
     // ==========================================
-    // ProcessManager が iframe.name に設定したプロセスIDを取得
-    const MY_PID = window.name || 'unknown';
+    // モバイル環境でのフォーITERA_PIDRA_PID__ を優先して取得
+    const MY_PID = window.__ITERA_PID__ || window.name || 'unknown';
     const transport = new GuestTransport(MY_PID);
 
     // ==========================================

--- a/src/core/control/guest_compiler.js
+++ b/src/core/control/guest_compiler.js
@@ -216,6 +216,14 @@ window.addEventListener('message', async (e) => {
 					}
 				}
 
+				// ★ モバイル環境での window.name 消失対策: グローバル変数として PID を直接注入
+				const pidScript = `<script>window.__ITERA_PID__ = '${pid}';</script>\n`;
+				if (htmlContent.includes('<head>')) {
+					htmlContent = htmlContent.replace('<head>', '<head>\n' + pidScript);
+				} else {
+					htmlContent = htmlContent.replace(/(<!DOCTYPE\s+html>)/i, `$1\n${pidScript}`);
+				}
+
 				// 2. Bridgeの注入 (Blob URL経由の外部スクリプト読み込み)
 				if (global.Itera.Api && global.Itera.Api.GuestBuilder) {
 					const bridgeUrl = global.Itera.Api.GuestBuilder.getBlobUrl();


### PR DESCRIPTION

## 原因
モバイル版のブラウザ（iOS Safari / Android Chrome 等）において、Blob URL を iframe で読み込んだ際に、サンドボックスの仕様により親ウィンドウから設定された `iframe.name` (`window.name`) が揮発・リセットされてしまう問題がありました。
このため、Guest 側が自身の PID を `'unknown'` として解決してしまい、動的ツールの登録時などに Host との逆方向 RPC でエラー (`Target process 'unknown' is no longer available.`) が発生していました。

## 修正内容
1. `guest_compiler.js`
   HTML のコンパイル時、`<head>` ブロック内に直接 `window.__ITERA_PID__ = '${pid}';` をインジェクトする処理を追加しました。
2. `guest_builder.js`
   Guest API の初期化時、`window.name` よりも先に `window.__ITERA_PID__` を優先して参照するように修正しました。

これにより、モバイル環境でも確実かつ安全にプロセスIDの受け渡しが行われるようになります。
